### PR TITLE
Updated ffmpeg parameters to be compatible with latest version.

### DIFF
--- a/libhikvision/__init__.py
+++ b/libhikvision/__init__.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 
 """ Import library like this: from libhikvision import libHikvision """
-name = "libhikvision"
 
 from struct import unpack
 from datetime import datetime
@@ -10,6 +9,7 @@ import os
 import subprocess
 import sqlite3
 
+name = "libhikvision"
 
 class libHikvision():
     """This library parses the Hikvision bin files and is able to extract the required media"""
@@ -258,9 +258,9 @@ class libHikvision():
 
             # Convert the h264 file to mp4
             if resolution is None:
-                cmd = 'ffmpeg -i {0} -threads auto -c:v copy -c:a none {1} -hide_banner'.format(h264_file, mp4_file)
+                cmd = 'ffmpeg -i {0} -threads auto -c:v copy -an {1} -hide_banner'.format(h264_file, mp4_file)
             else:
-                cmd = 'avconv -i {0} -threads auto -s {2} -c:a none {1}'.format(h264_file, mp4_file, resolution)
+                cmd = 'avconv -i {0} -threads auto -s {2} -an {1}'.format(h264_file, mp4_file, resolution)
             if debug:
                 subprocess.call(cmd, shell=True)
             else:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name='libhikvision',
-    version='0.3.9',
+    version='0.3.10',
     author="bkbilly",
     author_email="bkbilly@hotmail.com",
     description="Parse Hikvision datadirs that Hikvision IP cameras store the videos",


### PR DESCRIPTION
Hi @bkbilly,

First of all, thanks for this fantastic package. This has helped me tremendously!

While building my own solution to process Hikvision camera's I noticed that the ffmpeg command was faulty. To remove/ignore the audio stream of the video the parameter `-c:a none`. In previous versions of ffmpeg this was accepted, but with my current version v7.1.1 this resulted in a critical error `codec None not found`.

To solve this, I changed `-c:a none` to `-an`, which is the current way to indicate to ignore the audio stream.

Further, I bumped package version to 3.10, so hopefully your workflow automatically publishes the package to Pypi.